### PR TITLE
Add add_days() and mask() functions

### DIFF
--- a/core/src/main/cpp/parser/mpFuncCmplx.cpp
+++ b/core/src/main/cpp/parser/mpFuncCmplx.cpp
@@ -622,7 +622,7 @@ MUP_NAMESPACE_START
   //-----------------------------------------------------------------------
   const char_type* FunCmplxPow::GetDesc() const
   {
-    return _T("pox(x, y) - Raise x to the power of y.");
+    return _T("pow(x, y) - Raise x to the power of y.");
   }
 
   //-----------------------------------------------------------------------

--- a/core/src/main/cpp/parser/mpFuncCommon.h
+++ b/core/src/main/cpp/parser/mpFuncCommon.h
@@ -120,17 +120,31 @@ MUP_NAMESPACE_START
   }; // class FunSizeOf
 
   //------------------------------------------------------------------------------
-  /** \brief Determine the difference in days between two dates.
+  /** \brief Returns the application of a mask into a integer.
       \ingroup functions
   */
-  class FunDateDiff : public ICallback
+  class FunMask : public ICallback
   {
   public:
-    FunDateDiff();
+    FunMask();
+    virtual ~FunMask();
     virtual void Eval(ptr_val_type &ret, const ptr_val_type *a_pArg, int a_iArgc) override;
     virtual const char_type* GetDesc() const override;
     virtual IToken* Clone() const override;
-  }; // class FunDateDiff
+  }; // class FunMask
+
+  //------------------------------------------------------------------------------
+  /** \brief Determine the difference in days between two dates.
+      \ingroup functions
+  */
+  class FunDaysDiff : public ICallback
+  {
+  public:
+    FunDaysDiff();
+    virtual void Eval(ptr_val_type &ret, const ptr_val_type *a_pArg, int a_iArgc) override;
+    virtual const char_type* GetDesc() const override;
+    virtual IToken* Clone() const override;
+  }; // class FunDaysDiff
 
   //------------------------------------------------------------------------------
   /** \brief Determine the difference in hours between two dates.
@@ -159,6 +173,19 @@ MUP_NAMESPACE_START
   }; // class FunCurrentDate
 
   //------------------------------------------------------------------------------
+  /** \brief Return sum of a date/date_time with a days quantity
+      \ingroup functions
+  */
+  class FunAddDays : public ICallback
+  {
+  public:
+    FunAddDays();
+    virtual void Eval(ptr_val_type &ret, const ptr_val_type *a_pArg, int a_iArgc) override;
+    virtual const char_type* GetDesc() const override;
+    virtual IToken* Clone() const override;
+  }; // class FunAddDays
+
+  //------------------------------------------------------------------------------
   /** \brief Determine the difference in days between two time.
       \ingroup functions
   */
@@ -169,7 +196,7 @@ MUP_NAMESPACE_START
   //  virtual void Eval(ptr_val_type &ret, const ptr_val_type *a_pArg, int a_iArgc) override;
   //  virtual const char_type* GetDesc() const override;
   //  virtual IToken* Clone() const override;
-  //}; // class FunDateDiff
+  //}; // class FunDaysDiff
 
 MUP_NAMESPACE_END
 

--- a/core/src/main/cpp/parser/mpPackageCommon.cpp
+++ b/core/src/main/cpp/parser/mpPackageCommon.cpp
@@ -86,11 +86,14 @@ void PackageCommon::AddToParser(ParserXBase *pParser)
   pParser->DefineFun(new FunSum());
   pParser->DefineFun(new FunAvg());
 
+  // Special functions
+  pParser->DefineFun(new FunMask());
 
   // Date functions
-  pParser->DefineFun(new FunDateDiff());
+  pParser->DefineFun(new FunDaysDiff());
   pParser->DefineFun(new FunHoursDiff());
   pParser->DefineFun(new FunCurrentDate());
+  pParser->DefineFun(new FunAddDays());
 
   // misc
   pParser->DefineFun(new FunParserID);
@@ -103,7 +106,7 @@ void PackageCommon::AddToParser(ParserXBase *pParser)
   pParser->DefineOprt(new OprtShr);
   pParser->DefineOprt(new OprtShl);
 
-  // booloean package
+  // boolean package
   pParser->DefineOprt(new OprtLE);
   pParser->DefineOprt(new OprtGE);
   pParser->DefineOprt(new OprtLT);

--- a/core/src/main/cpp/parser/mpParserMessageProvider.cpp
+++ b/core/src/main/cpp/parser/mpParserMessageProvider.cpp
@@ -90,11 +90,11 @@ MUP_NAMESPACE_START
     m_vErrMsg[ecARRAY_SIZE_MISMATCH]      = _T("Array size mismatch.");
     m_vErrMsg[ecNOT_AN_ARRAY]             = _T("Using the index operator on the scalar variable \"$IDENT$\" is not allowed.");
     m_vErrMsg[ecUNEXPECTED_SQR_BRACKET]   = _T("Unexpected \"[]\".");
-    m_vErrMsg[ecUNEXPECTED_CURLY_BRACKET] = _T("Unexpected \"{}\".");
+	  m_vErrMsg[ecUNEXPECTED_CURLY_BRACKET] = _T("Unexpected \"{}\".");
     m_vErrMsg[ecINDEX_OUT_OF_BOUNDS]      = _T("Index to variable \"$IDENT$\" is out of bounds.");
     m_vErrMsg[ecINDEX_DIMENSION]          = _T("Index operator dimension error.");
     m_vErrMsg[ecMISSING_SQR_BRACKET]      = _T("Missing \"]\".");
-    m_vErrMsg[ecMISSING_CURLY_BRACKET]    = _T("Missing \"}\".");
+	  m_vErrMsg[ecMISSING_CURLY_BRACKET]    = _T("Missing \"}\".");
     m_vErrMsg[ecASSIGNEMENT_TO_VALUE]     = _T("Assignment operator \"$IDENT$\" can't be used in this context.");
     m_vErrMsg[ecEVAL]                     = _T("Can't evaluate function/operator \"$IDENT$\": $HINT$");
     m_vErrMsg[ecINVALID_PARAMETER]        = _T("Parameter $ARG$ of function \"$IDENT$\" is invalid.");
@@ -107,6 +107,9 @@ MUP_NAMESPACE_START
     m_vErrMsg[ecINVALID_DATE_FORMAT]          = _T("Invalid date format on parameter(s). Please use the \"yyyy-mm-dd\" format.");
     m_vErrMsg[ecINVALID_DATETIME_FORMAT]      = _T("Invalid format on the parameter(s). Please use two \"yyyy-mm-dd\" for dates OR two \"yyyy-mm-ddTHH:MM\" for date_times.");
     m_vErrMsg[ecDATE_AND_DATETIME]            = _T("Invalid parameters. You should use exactly two dates \"yyyy-mm-dd\" or two date_times \"yyyy-mm-ddTHH:MM\", but not a mix of them.");
+    m_vErrMsg[ecADD_HOURS]                    = _T("Invalid parameters. You should use a date \"yyyy-mm-dd\" or date_time \"yyyy-mm-ddTHH:MM\" on the first parameter and a number on the second parameter.");
+    m_vErrMsg[ecADD_HOURS_DATE]               = _T("The first parameter could not be converted to a date. Please use the format: \"yyyy-mm-dd\"");
+    m_vErrMsg[ecADD_HOURS_DATETIME]           = _T("The first parameter could not be converted to a date time. Please use the format: \"yyyy-mm-ddTHH:MM\"");
   }
 
 #if defined(_UNICODE)
@@ -164,11 +167,11 @@ MUP_NAMESPACE_START
     m_vErrMsg[ecARRAY_SIZE_MISMATCH]      = _T("Feldgrößen stimmen nicht überein.");
     m_vErrMsg[ecNOT_AN_ARRAY]             = _T("Der Indexoperator kann nicht auf die Skalarvariable \"$IDENT$\" angewandt werden.");
     m_vErrMsg[ecUNEXPECTED_SQR_BRACKET]   = _T("Eckige Klammern sind an dieser Position nicht erlaubt.");
-	m_vErrMsg[ecUNEXPECTED_CURLY_BRACKET] = _T("Geschweifte Klammern sind an dieser Position nicht erlaubt.");
+	  m_vErrMsg[ecUNEXPECTED_CURLY_BRACKET] = _T("Geschweifte Klammern sind an dieser Position nicht erlaubt.");
     m_vErrMsg[ecINDEX_OUT_OF_BOUNDS]      = _T("Indexüberschreitung bei Variablenzugriff auf \"$IDENT$\".");
     m_vErrMsg[ecINDEX_DIMENSION]          = _T("Die Operation kann nicht auf Felder angewandt werden, deren Größe unterschiedlich ist.");
     m_vErrMsg[ecMISSING_SQR_BRACKET]      = _T("Fehlendes \"]\".");
-	m_vErrMsg[ecMISSING_CURLY_BRACKET]    = _T("Fehlendes \"}\".");
+	  m_vErrMsg[ecMISSING_CURLY_BRACKET]    = _T("Fehlendes \"}\".");
     m_vErrMsg[ecASSIGNEMENT_TO_VALUE]     = _T("Der Zuweisungsoperator \"$IDENT$\" kann in diesem Zusammenhang nicht verwendet werden.");
     m_vErrMsg[ecEVAL]                     = _T("Die Funktion bzw. der Operator \"$IDENT$\" kann nicht berechnet werden: $HINT$");
     m_vErrMsg[ecINVALID_PARAMETER]        = _T("Der Parameter $ARG$ der Funktion \"$IDENT$\" is ungültig.");

--- a/core/src/main/cpp/parser/mpTypes.h
+++ b/core/src/main/cpp/parser/mpTypes.h
@@ -322,7 +322,7 @@ enum EErrorCodes
     ecARRAY_SIZE_MISMATCH       = 24, ///< Array size mismatch during a vector operation
     ecNOT_AN_ARRAY              = 25, ///< Using the index operator on a scalar variable
     ecUNEXPECTED_SQR_BRACKET    = 26, ///< Invalid use of the index operator
-    ecUNEXPECTED_CURLY_BRACKET  = 27, ///< Invalid use of the index operator
+	  ecUNEXPECTED_CURLY_BRACKET  = 27, ///< Invalid use of the index operator
 
     ecINVALID_NAME              = 28, ///< Invalid function, variable or constant name.
     ecBUILTIN_OVERLOAD          = 29, ///< Trying to overload builtin operator
@@ -343,7 +343,7 @@ enum EErrorCodes
     ecINDEX_OUT_OF_BOUNDS       = 40, ///< Array index is out of bounds
     ecINDEX_DIMENSION           = 41,
     ecMISSING_SQR_BRACKET       = 42, ///< The index operator was not closed properly (i.e. "v[3")
-    ecMISSING_CURLY_BRACKET     = 43,
+	  ecMISSING_CURLY_BRACKET     = 43,
     ecEVAL                      = 44, ///< Error while evaluating function / operator
     ecOVERFLOW                  = 45, ///< Overflow (possibly) occurred
 
@@ -365,6 +365,9 @@ enum EErrorCodes
     ecINVALID_DATE_FORMAT       = 52, ///< Invalid date format
     ecINVALID_DATETIME_FORMAT   = 53, ///< Invalid datetime format
     ecDATE_AND_DATETIME         = 54, ///< Invalid hoursdiff() parameters
+    ecADD_HOURS                 = 55, ///< Invalid add_hours() parameters
+    ecADD_HOURS_DATE            = 56, ///< Invalid date format for add_hours() first parameter
+    ecADD_HOURS_DATETIME        = 57, ///< Invalid date time format for add_hours() first parameter
 
     // The last two are special entries
     ecCOUNT,                          ///< This is no error code, It just stores the total number of error codes


### PR DESCRIPTION
## Description

Add `mask(string, number)` and `add_days(date, number)` functions to c++ library.

## The new functions

#### `mask(string, number)`
```ruby
mask(string, number)
# Result: The mask applied to a number

mask("000", 1) => "001"
mask("000", 1234) => "1234"
mask("000-000-000", 123456789) => "123-456-789"
mask("00/00/0000", 21011993) => "21/01/1993"

# Observation: You should not use a number that has more than 17 digits as a second parameter due to imprecision issues
```

#### `add_days(date, number)`
```ruby
add_days(date, number)
# Result: The addition (in days) between a date and a days quantity.

add_days("2019-01-01", 3) => "2019-01-04"
add_days("2019-01-01T08:30", -1) => "2018-12-31T08:30"
```


### Checks

- [x] Update Parsec library with add_days() and mask() functions
- [x] Add new errors
- [x] Refactor the whole date section with new auxiliar functions
