### PR TITLE
Update Parsec library with default_value() function

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -8,7 +8,7 @@ android {
         minSdkVersion 21
         targetSdkVersion 27
         versionCode 3
-        versionName "0.1.3"
+        versionName "0.2.1"
         externalNativeBuild {
             cmake {
                 cppFlags "-frtti -fexceptions"

--- a/core/src/main/cpp/parser/mpFuncStr.cpp
+++ b/core/src/main/cpp/parser/mpFuncStr.cpp
@@ -140,6 +140,125 @@ MUP_NAMESPACE_START
 
   //------------------------------------------------------------------------------
   //
+
+  // default_value() auxiliary overloading functions
+  //
+  //------------------------------------------------------------------------------
+
+  int_type default_value(int_type value, int_type standard) {
+    return value == NULL ? standard : value;
+  }
+
+  float_type default_value(float_type value, float_type standard) {
+    return value == NULL ? standard : value;
+  }
+
+  string_type default_value(string_type value, string_type standard) {
+    return value.empty() ? standard : value;
+  }
+
+  // If the value is an integer, it is NULL, therefore return standard
+  string_type default_value(int_type value, string_type standard) {
+    return standard;
+  }
+
+  bool_type default_value(bool_type value, bool_type standard) {
+    return value;
+  }
+
+  // If the value is an integer, it is NULL, therefore return standard
+  bool_type default_value(int_type value, bool_type standard) {
+    return standard;
+  }
+
+  //------------------------------------------------------------------------------
+  //
+  // Default Value function
+  //
+  //------------------------------------------------------------------------------
+
+  FunStrDefaultValue::FunStrDefaultValue()
+    :ICallback(cmFUNC, _T("default_value"), 2)
+  {}
+
+  //------------------------------------------------------------------------------
+  void FunStrDefaultValue::Eval(ptr_val_type &ret, const ptr_val_type *a_pArg, int)
+  {
+
+    int_type integer_value;
+    int_type integer_standard;
+    float_type float_value;
+    float_type float_standard;
+    string_type string_value;
+    string_type string_standard;
+    bool_type bool_value;
+    bool_type bool_standard;
+
+    if (a_pArg[0]->GetType() != a_pArg[1]->GetType()) {
+      if (a_pArg[0]->GetInteger() != NULL) {
+        throw ParserError(ErrorContext(ecINVALID_TYPES_MATCH, GetExprPos(), GetIdent()));
+      }
+    }
+
+    if (a_pArg[1]->GetType() == 'i') {
+      integer_standard = a_pArg[1]->GetInteger();
+      integer_value = a_pArg[0]->GetInteger();
+      *ret = (int_type) default_value(integer_value, integer_standard);
+
+      return;
+    }
+
+    if (a_pArg[1]->GetType() == 'f') {
+      float_standard = a_pArg[1]->GetFloat();
+      float_value = a_pArg[0]->GetFloat();
+      *ret = (float_type) default_value(float_value, float_standard);
+
+      return;
+    }
+
+    if (a_pArg[1]->GetType() == 'b') {
+      bool_standard = a_pArg[1]->GetBool();
+
+      if (a_pArg[0]->GetType() == 'i') {
+        integer_value = a_pArg[0]->GetInteger();
+        *ret = default_value(integer_value, bool_standard);
+      } else if (a_pArg[0]->GetType() == 'b') {
+        bool_value = a_pArg[0]->GetBool();
+        *ret = (bool_type) default_value(bool_value, bool_standard);
+      }
+
+      return;
+    }
+
+    if (a_pArg[1]->GetType() == 's') {
+      string_standard = a_pArg[1]->GetString();
+
+      if (a_pArg[0]->GetType() == 'i') {
+        integer_value = a_pArg[0]->GetInteger();
+        *ret = default_value(integer_value, string_standard);
+      } else if (a_pArg[0]->GetType() == 's') {
+        string_value = a_pArg[0]->GetString();
+        *ret = (string_type) default_value(string_value, string_standard);
+      }
+
+      return;
+    }
+  }
+
+  //------------------------------------------------------------------------------
+  const char_type* FunStrDefaultValue::GetDesc() const
+  {
+    return _T("default_value(value, standard) - If value is NULL return standard, otherwise return value");
+  }
+
+  //------------------------------------------------------------------------------
+  IToken* FunStrDefaultValue::Clone() const
+  {
+    return new FunStrDefaultValue(*this);
+  }
+
+  //------------------------------------------------------------------------------
+  //
   // Length function
   //
   //------------------------------------------------------------------------------
@@ -254,7 +373,7 @@ MUP_NAMESPACE_START
                   // ist. sscanf und long double geht nicht mit GCC!
 
     in = a_pArg[0]->GetString();
-    
+
 #ifndef _UNICODE    
     sscanf(in.c_str(), "%lf", &out);
 #else

--- a/core/src/main/cpp/parser/mpFuncStr.h
+++ b/core/src/main/cpp/parser/mpFuncStr.h
@@ -77,6 +77,19 @@ MUP_NAMESPACE_START
   };
 
   //------------------------------------------------------------------------------
+  /** \brief Callback object for determining the default value for a string.
+      \ingroup functions
+  */
+  class FunStrDefaultValue : public ICallback
+  {
+  public:
+    FunStrDefaultValue();
+    virtual void Eval(ptr_val_type& ret, const ptr_val_type *a_pArg, int a_iArgc) override;
+    virtual const char_type* GetDesc() const override;
+    virtual IToken* Clone() const override;
+  };
+
+  //------------------------------------------------------------------------------
   /** \brief Callback object for determining the length of a string. 
       \ingroup functions
   */

--- a/core/src/main/cpp/parser/mpPackageCommon.cpp
+++ b/core/src/main/cpp/parser/mpPackageCommon.cpp
@@ -45,6 +45,9 @@
 /** \brief The eulerian number. */
 #define MUP_CONST_E   2.718281828459045235360287
 
+/** \brief Allow NULL constant to be used inside lib. */
+#define MUP_CONST_NULL   NULL
+
 
 MUP_NAMESPACE_START
 
@@ -76,6 +79,7 @@ void PackageCommon::AddToParser(ParserXBase *pParser)
   // Constants
   pParser->DefineConst( _T("pi"), (float_type)MUP_CONST_PI );
   pParser->DefineConst( _T("e"),  (float_type)MUP_CONST_E );
+  pParser->DefineConst( _T("NULL"), (int_type)MUP_CONST_NULL );
 
   // Vector
   pParser->DefineFun(new FunSizeOf());

--- a/core/src/main/cpp/parser/mpPackageStr.cpp
+++ b/core/src/main/cpp/parser/mpPackageStr.cpp
@@ -65,6 +65,7 @@ void PackageStr::AddToParser(ParserXBase *pParser)
   pParser->DefineFun(new FunStrConcat());
   pParser->DefineFun(new FunStrLeft());
   pParser->DefineFun(new FunStrRight());
+  pParser->DefineFun(new FunStrDefaultValue());
 
   // Operators
   pParser->DefineOprt(new OprtStrAdd);

--- a/core/src/main/cpp/parser/mpParserMessageProvider.cpp
+++ b/core/src/main/cpp/parser/mpParserMessageProvider.cpp
@@ -110,6 +110,7 @@ MUP_NAMESPACE_START
     m_vErrMsg[ecADD_HOURS]                    = _T("Invalid parameters. You should use a date \"yyyy-mm-dd\" or date_time \"yyyy-mm-ddTHH:MM\" on the first parameter and a number on the second parameter.");
     m_vErrMsg[ecADD_HOURS_DATE]               = _T("The first parameter could not be converted to a date. Please use the format: \"yyyy-mm-dd\"");
     m_vErrMsg[ecADD_HOURS_DATETIME]           = _T("The first parameter could not be converted to a date time. Please use the format: \"yyyy-mm-ddTHH:MM\"");
+    m_vErrMsg[ecINVALID_TYPES_MATCH]          = _T("Both values of the default(x, y) function should have the same type");
   }
 
 #if defined(_UNICODE)

--- a/core/src/main/cpp/parser/mpTypes.h
+++ b/core/src/main/cpp/parser/mpTypes.h
@@ -369,6 +369,8 @@ enum EErrorCodes
     ecADD_HOURS_DATE            = 56, ///< Invalid date format for add_hours() first parameter
     ecADD_HOURS_DATETIME        = 57, ///< Invalid date time format for add_hours() first parameter
 
+    ecINVALID_TYPES_MATCH       = 58,
+
     // The last two are special entries
     ecCOUNT,                          ///< This is no error code, It just stores the total number of error codes
     ecUNDEFINED                 = -1  ///< Undefined message, placeholder to detect unassigned error messages

--- a/core/src/main/cpp/value_test/mpError.cpp
+++ b/core/src/main/cpp/value_test/mpError.cpp
@@ -113,6 +113,7 @@ MUP_NAMESPACE_START
     m_vErrMsg[ecINVALID_DATE_FORMAT]     = _T("Invalid date format on parameter(s). Please use the \"yyyy-mm-dd\" format.");
     m_vErrMsg[ecINVALID_DATETIME_FORMAT] = _T("Invalid format on the parameter(s). Please use two \"yyyy-mm-dd\" for dates OR two \"yyyy-mm-ddTHH:MM\" for date_times.");
     m_vErrMsg[ecDATE_AND_DATETIME]       = _T("Invalid parameters. You should use exactly two dates \"yyyy-mm-dd\" or two date_times \"yyyy-mm-ddTHH:MM\", but not a mix of them.");
+    m_vErrMsg[ecINVALID_TYPES_MATCH]     = _T("Both values of the default(x, y) function should have the same type");
 
     #if defined(_DEBUG)
       for (int i=0; i<ecCOUNT; ++i)

--- a/core/src/main/cpp/value_test/mpError.h
+++ b/core/src/main/cpp/value_test/mpError.h
@@ -102,6 +102,8 @@ MUP_NAMESPACE_START
       ecINVALID_DATETIME_FORMAT   = 53, ///< Invalid datetime format
       ecDATE_AND_DATETIME         = 54, ///< Invalid hoursdiff() parameters
 
+      ecINVALID_TYPES_MATCH       = 58, ///< Both values of the default(x, y) function should have the same type
+
       // The last two are special entries 
       ecCOUNT,                    ///< This is no error code, It just stores just the total number of error codes
       ecUNDEFINED              = -1, ///< Undefined message, placeholder to detect unassigned error messages


### PR DESCRIPTION
**Reference:** https://github.com/niltonvasques/equations-parser/pull/29#issue-437711024

# Description

- [x] Increase version from `0.1.3` to `0.2.1` due addition of new feature (in release tags, the version is already 0.2.0)
- [x] Adda new function on the library.:

```C
default_value(value, standard)
```

If the **value** is `NULL`, the result of this function is the **standard**, otherwise, the result is the **value**.

This function accept both `integer`, `float`, `string` and `boolean` types. (C++ overloading for the win)

Some success test samples: :white_check_mark:

```C
default_value(10, 1)
default_value(NULL, 1)
default_value(10.4, 1.01)
default_value(NULL, 1.01)
default_value("filled", "default")
default_value(NULL, "default")
default_value(false, true)
default_value(NULL, true)
```

Some failure test samples: :no_entry_sign:

```C
default_value(1, 4.5)
default_value(4.5, "string")
default_value("string", true)
default_value(true, 1)
```

This PR also add a new constant on the lib: the `NULL` constant.