### PR TITLE
Fix default_value() numbers incompatibility

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -8,7 +8,7 @@ android {
         minSdkVersion 21
         targetSdkVersion 27
         versionCode 3
-        versionName "0.2.1"
+        versionName "0.2.4"
         externalNativeBuild {
             cmake {
                 cppFlags "-frtti -fexceptions"

--- a/core/src/main/cpp/parser/mpFuncStr.cpp
+++ b/core/src/main/cpp/parser/mpFuncStr.cpp
@@ -145,10 +145,6 @@ MUP_NAMESPACE_START
   //
   //------------------------------------------------------------------------------
 
-  int_type default_value(int_type value, int_type standard) {
-    return value == NULL ? standard : value;
-  }
-
   float_type default_value(float_type value, float_type standard) {
     return value == NULL ? standard : value;
   }
@@ -184,7 +180,6 @@ MUP_NAMESPACE_START
   //------------------------------------------------------------------------------
   void FunStrDefaultValue::Eval(ptr_val_type &ret, const ptr_val_type *a_pArg, int)
   {
-
     int_type integer_value;
     int_type integer_standard;
     float_type float_value;
@@ -194,21 +189,19 @@ MUP_NAMESPACE_START
     bool_type bool_value;
     bool_type bool_standard;
 
-    if (a_pArg[0]->GetType() != a_pArg[1]->GetType()) {
+    char first_param_type = a_pArg[0]->GetType();
+    char second_param_type = a_pArg[1]->GetType();
+
+    first_param_type = first_param_type == 'i' ? 'f' : first_param_type;
+    second_param_type = second_param_type == 'i' ? 'f' : second_param_type;
+
+    if (first_param_type != second_param_type) {
       if (a_pArg[0]->GetInteger() != NULL) {
         throw ParserError(ErrorContext(ecINVALID_TYPES_MATCH, GetExprPos(), GetIdent()));
       }
     }
 
-    if (a_pArg[1]->GetType() == 'i') {
-      integer_standard = a_pArg[1]->GetInteger();
-      integer_value = a_pArg[0]->GetInteger();
-      *ret = (int_type) default_value(integer_value, integer_standard);
-
-      return;
-    }
-
-    if (a_pArg[1]->GetType() == 'f') {
+    if (second_param_type == 'f') {
       float_standard = a_pArg[1]->GetFloat();
       float_value = a_pArg[0]->GetFloat();
       *ret = (float_type) default_value(float_value, float_standard);
@@ -216,13 +209,13 @@ MUP_NAMESPACE_START
       return;
     }
 
-    if (a_pArg[1]->GetType() == 'b') {
+    if (second_param_type == 'b') {
       bool_standard = a_pArg[1]->GetBool();
 
-      if (a_pArg[0]->GetType() == 'i') {
+      if (a_pArg[0]->GetType() == 'i') { // NULL first parameter
         integer_value = a_pArg[0]->GetInteger();
         *ret = default_value(integer_value, bool_standard);
-      } else if (a_pArg[0]->GetType() == 'b') {
+      } else if (a_pArg[0]->GetType() == 'b') { // NOT NULL first parameter
         bool_value = a_pArg[0]->GetBool();
         *ret = (bool_type) default_value(bool_value, bool_standard);
       }
@@ -230,13 +223,13 @@ MUP_NAMESPACE_START
       return;
     }
 
-    if (a_pArg[1]->GetType() == 's') {
+    if (second_param_type == 's') {
       string_standard = a_pArg[1]->GetString();
 
-      if (a_pArg[0]->GetType() == 'i') {
+      if (a_pArg[0]->GetType() == 'i') { // NULL first parameter
         integer_value = a_pArg[0]->GetInteger();
         *ret = default_value(integer_value, string_standard);
-      } else if (a_pArg[0]->GetType() == 's') {
+      } else if (a_pArg[0]->GetType() == 's'){ // NOT NULL first parameter
         string_value = a_pArg[0]->GetString();
         *ret = (string_type) default_value(string_value, string_standard);
       }


### PR DESCRIPTION
# Description 🗒️ 

This PRs converts integers to floats inside the `default_value()` evaluation, fixing the `default_value()` numbers incompatibility issue.

### Changes:

- [x] Update version to `0.2.4` for release 

last version published on jitpack `0.2.3`:
![DeepinScreenshot_select-area_20201009130255](https://user-images.githubusercontent.com/3251916/95605834-e401dc80-0a2f-11eb-9cd3-aecf28947e3e.png)

- [x] Fix issue associated with result of different types of number parameters

Now, this function is much more flexible to play with **integer** and **float** parameters.

For example...

```rb
parsec> default_value(1, 10)
Result (type: 'i'):
ans = 1

parsec> default_value(1, 10.0)
Result (type: 'i'):
ans = 1

parsec> default_value(1.0, 10)
Result (type: 'i'):
ans = 1

parsec> default_value(1.0, 10.0)
Result (type: 'i'):
ans = 1

parsec> default_value(1.5, 10)
Result (type: 'f'):
ans = 1.5

parsec> default_value(1.5, 10.0)
Result (type: 'f'):
ans = 1.5

parsec> default_value(1.5, 10.5)
Result (type: 'f'):
ans = 1.5
```

# The Bug 🐛 

![SLA error reason](https://user-images.githubusercontent.com/7637806/95136053-c97fe880-073b-11eb-8b88-a21901fba20c.png)

Reference: https://github.com/niltonvasques/equations-parser/pull/31