### PR TITLE
DPMS-14885 Updating parsec native code - Add timediff function and fix right function

### DIFF
--- a/core/src/main/cpp/parser/mpFuncCommon.h
+++ b/core/src/main/cpp/parser/mpFuncCommon.h
@@ -186,17 +186,17 @@ MUP_NAMESPACE_START
   }; // class FunAddDays
 
   //------------------------------------------------------------------------------
-  /** \brief Determine the difference in days between two time.
+  /** \brief Determine the difference in hours between two times.
       \ingroup functions
   */
-  //class FunTimeDiff : public ICallback
-  //{
-  //public:
-  //  FunTimeDiff();
-  //  virtual void Eval(ptr_val_type &ret, const ptr_val_type *a_pArg, int a_iArgc) override;
-  //  virtual const char_type* GetDesc() const override;
-  //  virtual IToken* Clone() const override;
-  //}; // class FunDaysDiff
+  class FunTimeDiff : public ICallback
+  {
+  public:
+    FunTimeDiff();
+    virtual void Eval(ptr_val_type &ret, const ptr_val_type *a_pArg, int a_iArgc) override;
+    virtual const char_type* GetDesc() const override;
+    virtual IToken* Clone() const override;
+  }; // class FunTimeDiff
 
 MUP_NAMESPACE_END
 

--- a/core/src/main/cpp/parser/mpFuncStr.cpp
+++ b/core/src/main/cpp/parser/mpFuncStr.cpp
@@ -182,6 +182,8 @@ MUP_NAMESPACE_START
     string_type str = a_pArg[0]->GetString();
     int cut = a_pArg[1]->GetInteger();
 
+    cut = std::min(cut, (int)str.size());
+
     str = str.substr(str.size() - cut, str.size());
 
     *ret = (string_type) str;

--- a/core/src/main/cpp/parser/mpPackageCommon.cpp
+++ b/core/src/main/cpp/parser/mpPackageCommon.cpp
@@ -100,6 +100,9 @@ void PackageCommon::AddToParser(ParserXBase *pParser)
   pParser->DefineFun(new FunCurrentDate());
   pParser->DefineFun(new FunAddDays());
 
+  // Time functions
+  pParser->DefineFun(new FunTimeDiff());
+
   // misc
   pParser->DefineFun(new FunParserID);
 

--- a/core/src/main/cpp/parser/mpTypes.h
+++ b/core/src/main/cpp/parser/mpTypes.h
@@ -371,6 +371,9 @@ enum EErrorCodes
 
     ecINVALID_TYPES_MATCH       = 58,
 
+    // time related errors
+    ecINVALID_TIME_FORMAT       = 59, ///< Invalid time format
+
     // The last two are special entries
     ecCOUNT,                          ///< This is no error code, It just stores the total number of error codes
     ecUNDEFINED                 = -1  ///< Undefined message, placeholder to detect unassigned error messages


### PR DESCRIPTION
This PR aims to update the parsec native code with following commits:
- [x] [Add timediff(start_date, end_date) function to calculate a time difference in hours (#37)](https://github.com/niltonvasques/equations-parser/pull/37)
- [x] [Fix right(x, y) function to work with cut size bigger than string length (#38)](https://github.com/niltonvasques/equations-parser/pull/38)

* Jira ticket: https://kaeferdpms.atlassian.net/browse/DPMS-14885