### PR TITLE
Adds optional param download to link equation

### DIFF
--- a/core/src/main/cpp/parser/mpFuncStr.cpp
+++ b/core/src/main/cpp/parser/mpFuncStr.cpp
@@ -110,21 +110,27 @@ MUP_NAMESPACE_START
   //------------------------------------------------------------------------------
 
   FunStrLink::FunStrLink()
-    :ICallback(cmFUNC, _T("link"), 2)
+    :ICallback(cmFUNC, _T("link"), -1)
   {}
 
   //------------------------------------------------------------------------------
-  void FunStrLink::Eval(ptr_val_type &ret, const ptr_val_type *a_pArg, int)
+  void FunStrLink::Eval(ptr_val_type &ret, const ptr_val_type *a_pArg, int a_iArgc)
   {
+    if (a_iArgc < 2)
+      throw ParserError(ErrorContext(ecTOO_FEW_PARAMS, GetExprPos(), GetIdent()));
+    if (a_iArgc > 3)
+      throw ParserError(ErrorContext(ecTOO_MANY_PARAMS, GetExprPos(), GetIdent()));
     string_type str1 = a_pArg[0]->GetString();
     string_type str2 = a_pArg[1]->GetString();
-    *ret = (string_type) "<a href=\"" + str2 +"\">" + str1 + "</a>";
+    string_type opAttr = a_iArgc == 3 ? " download=\"" + a_pArg[2]->GetString() + "\">" : ">";
+    *ret = (string_type) "<a href=\"" + str2 +"\"" + opAttr + str1 + "</a>";
   }
 
   //------------------------------------------------------------------------------
   const char_type* FunStrLink::GetDesc() const
   {
-    return _T("link(s1, s2) - Returns the <a href=\"s2\">s1</a> tag with param values.");
+    return _T("link(s1, s2) - Returns the <a href=\"s2\">s1</a> tag with param values.")
+           _T("link(s1, s2, s3) - Returns the <a href=\"s2\" download=\"s3\">s1</a> tag with param values.");
   }
 
   //------------------------------------------------------------------------------


### PR DESCRIPTION
This PR adds optional param download to link equation, to be used in download attribute at anchor tag returned.

This PR is based on other PR changes at parsec web repository:

- [Adds optional attribute download to link() equation #39](https://github.com/niltonvasques/equations-parser/pull/39/files)
- [ Fixes space in link 2 params format on link() function with 3 parameters #40 ](https://github.com/niltonvasques/equations-parser/pull/40/files)
