### PR TITLE
Fixing float precision when converting AsString

### DIFF
--- a/core/src/main/cpp/parsec-lib.cpp
+++ b/core/src/main/cpp/parsec-lib.cpp
@@ -72,7 +72,7 @@ jstring CalcJson(JNIEnv *env, string input) {
         parser.SetExpr(input);
         ans = parser.Eval();
 
-        std::string ansString = ans.ToString();
+        std::string ansString = ans.AsString();
 
         replaceAll(ansString, "\"", "\\\"");
 
@@ -115,7 +115,7 @@ Java_br_com_nvsistemas_parsec_Parsec_nativeEval(JNIEnv *env, jobject /* this */,
     const char *inputChars = env->GetStringUTFChars(input, NULL);
 
     Value ans = Calc(string(inputChars));
-    return env->NewStringUTF(ans.ToString().c_str());
+    return env->NewStringUTF(ans.AsString().c_str());
 }
 
 extern "C" JNIEXPORT jstring JNICALL

--- a/core/src/main/cpp/parser/mpValue.cpp
+++ b/core/src/main/cpp/parser/mpValue.cpp
@@ -33,7 +33,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "mpValue.h"
 #include "mpError.h"
 #include "mpValueCache.h"
-
+#include <iomanip>
 
 MUP_NAMESPACE_START
 
@@ -764,7 +764,7 @@ string_type Value::AsString() const
     switch (m_cType)
     {
     case 'i': ss << (int_type)m_val.real(); break;
-    case 'f': ss << m_val.real(); break;
+    case 'f': ss << std::setprecision(std::numeric_limits<float_type>::digits10) << GetFloat(); break;
     case 'm': ss << _T("(matrix)"); break;
     case 's':
         assert(m_psVal != nullptr);


### PR DESCRIPTION
## Description

This PR aims to fix the float precision when converting as String .

Now the `AsString` function returns much higher numerical precision for `float` values:

| Before | Now |
| ------------------- | ------------------- |
|![parsec precision before](https://user-images.githubusercontent.com/13650290/203382597-8cba4b9e-41f8-4581-a199-43c0336fdf0b.png) |![parsec precision now](https://user-images.githubusercontent.com/13650290/203387547-5e8b0d8e-f061-46f5-a955-50a2cbcaf71f.png) |


Also in this PR, the `AsString` function is used again instead of `ToString`, as it was inserting extra quotes in the String values:

| Before | Now |
| ------------------- | ------------------- |
| ![string parsec bug](https://user-images.githubusercontent.com/13650290/203389177-387f5263-3219-4c30-97a3-88b1f8d7d7a8.png) |![string parsec](https://user-images.githubusercontent.com/13650290/203389236-c4f47863-753a-4420-9699-ed3733f6893a.png) |






**Includes the following commit from `equations-parser`:**
[Fixing float precision when converting AsString #42](https://github.com/niltonvasques/equations-parser/pull/42)
